### PR TITLE
Add Aggregate delay / duration data

### DIFF
--- a/custom_components/realtime_trains_api/sensor.py
+++ b/custom_components/realtime_trains_api/sensor.py
@@ -29,6 +29,7 @@ ATTR_REQUEST_TIME = "request_time"
 ATTR_JOURNEY_START = "journey_start"
 ATTR_JOURNEY_END = "journey_end"
 ATTR_NEXT_TRAINS = "next_trains"
+ATTR_AGGREGATE = "aggregate_data"
 
 CONF_API_USERNAME = "username"
 CONF_API_PASSWORD = "password"
@@ -136,6 +137,7 @@ class RealtimeTrainLiveTrainTimeSensor(SensorEntity):
         self._journey_end = journey_end
         self._journey_data_for_next_X_trains = journey_data_for_next_X_trains
         self._next_trains = []
+        self._aggregate_data = {}
         self._data = {}
         self._username = username
         self._password = password
@@ -190,6 +192,7 @@ class RealtimeTrainLiveTrainTimeSensor(SensorEntity):
                     "service_uid": departure["serviceUid"],
                     "scheduled": scheduledTs.strftime(STRFFORMAT),
                     "estimated": estimatedTs.strftime(STRFFORMAT),
+                    "delay": _delta_secs(estimatedTs, scheduledTs) // 60,
                     "minutes": _delta_secs(estimatedTs, now) // 60,
                     "platform": departure["locationDetail"].get("platform", None),
                     "operator_name": departure["atocName"],
@@ -197,6 +200,7 @@ class RealtimeTrainLiveTrainTimeSensor(SensorEntity):
             if departureCount <= self._journey_data_for_next_X_trains:
                 await self._add_journey_data(train, scheduledTs, estimatedTs)
             self._next_trains.append(train)
+        self._aggregate_data = await self._calculate_aggregates()
 
         if nextDepartureEstimatedTs is None:
             self._state = "No Departures"
@@ -248,6 +252,7 @@ class RealtimeTrainLiveTrainTimeSensor(SensorEntity):
                             "stops_of_interest": stopsOfInterest,
                             "scheduled_arrival": scheduled_arrival.strftime(STRFFORMAT),
                             "estimate_arrival": estimated_arrival.strftime(STRFFORMAT),
+                            "arrival_delay":  _delta_secs(estimated_arrival, scheduled_arrival) // 60,
                             "journey_time_mins": _delta_secs(estimated_arrival, estimated_departure) // 60,
                             "stops": stopCount
                         }
@@ -263,6 +268,7 @@ class RealtimeTrainLiveTrainTimeSensor(SensorEntity):
                                 "name": stop['description'],
                                 "scheduled_stop": scheduled_stop.strftime(STRFFORMAT),
                                 "estimate_stop": estimated_stop.strftime(STRFFORMAT),
+                                "stop_delay":  _delta_secs(estimated_stop, scheduled_stop) // 60,
                                 "journey_time_mins": _delta_secs(estimated_stop, estimated_departure) // 60,
                                 "stops": stopCount
                             }
@@ -273,6 +279,54 @@ class RealtimeTrainLiveTrainTimeSensor(SensorEntity):
             else:
                 _LOGGER.warning(f"Could not populate arrival times: Invalid response from API (HTTP code {response.status})")
 
+    async def _calculate_aggregates(self):
+        """Calculate aggregate delay and duration data."""
+        departure_delays = []
+        arrival_delays = []
+        stop_delays = []
+        durations = []
+        agg_delays = {}
+        for train in self._next_trains:
+            if 'journey_time_mins' in train:
+                durations.append(train['journey_time_mins'])
+            if 'delay' in train and train['delay'] > 0:
+                departure_delays.append(train['delay'])
+            if 'arrival_delay' in train and train['arrival_delay'] > 0:
+                arrival_delays.append(train['arrival_delay'])
+            if 'stop_delay' in train and train['stop_delay'] > 0:
+                stop_delays.append(train['stop_delay'])
+
+        if len(arrival_delays):
+            agg_delays['arrival'] = {
+                'count': len(arrival_delays),
+                'min': min(arrival_delays),
+                'max': max(arrival_delays),
+                'average': round( sum(arrival_delays) / len(arrival_delays) )
+            }
+        if len(departure_delays):
+            agg_delays['departure'] = {
+                'count': len(departure_delays),
+                'min': min(departure_delays),
+                'max': max(departure_delays),
+                'average': round( sum(departure_delays) / len(departure_delays) )
+            }
+        if len(stop_delays):
+            agg_delays['stop'] = {
+                'count': len(stop_delays),
+                'min': min(stop_delays),
+                'max': max(stop_delays),
+                'average': round( sum(stop_delays) / len(stop_delays) )
+            }
+        return {
+            'delays': agg_delays,
+            'durations': {
+                'count': len(durations),
+                'min': min(durations),
+                'max': max(durations),
+                'average': round( sum(durations) / len(durations) )
+            }
+        }
+
     @property
     def extra_state_attributes(self):
         """Return other details about the sensor state."""
@@ -282,6 +336,7 @@ class RealtimeTrainLiveTrainTimeSensor(SensorEntity):
             attrs[ATTR_JOURNEY_END] = self._journey_end
             if self._next_trains:
                 attrs[ATTR_NEXT_TRAINS] = self._next_trains
+                attrs[ATTR_AGGREGATE] = self._aggregate_data
             return attrs
 
 def _to_colonseparatedtime(hhmm_time_str : str) -> str:


### PR DESCRIPTION
Adds a 'delay' value to the departure, stop and arrival based on the local (estimatedTs - scheduledTs) for each.

Also aggregates this data across all tracked trains to give a `count`, `min`, `average` and `max` delay, along with similar stats for `durations` using existings data.

Adds this as an attribute alongside `next_trains` called `aggregate_data`
```
aggregate_data:
  delays:
    arrival:
      count: 1
      min: 42
      max: 42
      average: 42
    stop:
      count: 4
      min: 1
      max: 43
      average: 17
    departure:
      count: 4
      min: 1
      max: 43
      average: 17
  durations:
    count: 10
    min: 24
    max: 52
    average: 34
```

I use this in a mushroom card like this...
![12E3DD5E-74AD-40A8-BD02-E6105B833D61](https://user-images.githubusercontent.com/320214/185246390-c2cc580c-c2bd-462f-85a8-f8ac1444a0c1.png)
```
type: custom:mushroom-template-card
primary: Start to End
secondary: >-
  Leaving: 
  {{states.sensor.next_train_from_abc_to_def.attributes.aggregate_data.delays.departure.count}}
  trains
  ({{states.sensor.next_train_from_abc_to_def.attributes.aggregate_data.delays.departure.average}}m)

  Arrive:
  {{states.sensor.next_train_from_abc_to_def.attributes.aggregate_data.delays.arrival.count}}
  trains
  ({{states.sensor.next_train_from_abc_to_def.attributes.aggregate_data.delays.arrival.average}}m)

  Shortest:
  {{states.sensor.next_train_from_abc_to_def.attributes.aggregate_data.durations.min}}
  mins
icon: ''
entity: sensor.next_train_from_abc_to_def
multiline_secondary: true
layout: vertical
fill_container: false
```
Although template sensors can be used to extract the data.