### PR TITLE
Fix crash when no journey durations are available

### DIFF
--- a/custom_components/realtime_trains_api/sensor.py
+++ b/custom_components/realtime_trains_api/sensor.py
@@ -331,14 +331,18 @@ class RealtimeTrainLiveTrainTimeSensor(SensorEntity):
                 'max': max(stop_delays),
                 'average': round( sum(stop_delays) / len(stop_delays) )
             }
-        return {
-            'delays': agg_delays,
-            'durations': {
+        durations_data = None
+        if durations:
+            durations_data = {
                 'count': len(durations),
                 'min': min(durations),
                 'max': max(durations),
-                'average': round( sum(durations) / len(durations) )
+                'average': round(sum(durations) / len(durations)),
             }
+
+        return {
+            'delays': agg_delays,
+            'durations': durations_data,
         }
 
     @property


### PR DESCRIPTION
Fix ValueError when no duration data is returned

When no journey_time_mins values are present, the durations list is empty
and min()/max() raise a ValueError, causing HA entity updates to fail.

This change safely omits duration aggregates when no data is available.
